### PR TITLE
Cache coursier assets on CI

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,8 +19,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: coursier/cache-action@v3
+        with:
+          extraFiles: cs
       - name: Test
-        run:  ./ci scalafmt --test
+        run:  ./ci scalafmt-test
 
   test:
     strategy:
@@ -30,6 +33,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: coursier/cache-action@v3
+        with:
+          extraFiles: cs
       - name: Test
         run:  ./ci test
 
@@ -53,6 +59,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - uses: coursier/cache-action@v3
+        with:
+          extraFiles: cs
       - name: Build pages
         run:  ./ci gh-pages
       - name: Deploy pages

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,4 @@
 # Documentation: https://scalameta.org/scalafmt/docs/configuration.html
-version = "2.4.2"
-maxColumn = 80
-align = more
-includeCurlyBraceInSelectChains = false
-optIn.breakChainOnFirstMethodDot = true
 
+# Exclude from .gitignore
+project.git = true

--- a/ci
+++ b/ci
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex -o pipefail
 
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 case "$1" in
 
  jitpack)
@@ -33,6 +35,10 @@ case "$1" in
    exec $0 cs launch scalafmt -- --mode diff --diff-branch master "${@:2}"
  ;;
 
+ scalafmt-test)
+   exec $0 scalafmt --test
+ ;;
+
  mdoc-gen)
    $0 mill drivers.all._.mdocProperties
    $0 mdoc-js -i docs/doc1.md -o docs/doc2.md
@@ -51,11 +57,11 @@ case "$1" in
  ;;
 
  mill)
-   exec $0 cs launch --scala "$(awk '/^scala/{print$2}' .tool-versions)" mill:"$(< .mill-version)" -- "${@:2}"
+   exec $0 cs launch --scala "$(awk '/^scala/{print$2}' $BASE_DIR/.tool-versions)" mill:"$(< $BASE_DIR/.mill-version)" -- "${@:2}"
  ;;
 
  mill-i)
-   exec $0 cs launch --scala "$(awk '/^scala/{print$2}' .tool-versions)"  mill-interactive:"$(< .mill-version)" -- -i "${@:2}"
+   exec $0 cs launch --scala "$(awk '/^scala/{print$2}' $BASE_DIR/.tool-versions)"  mill-interactive:"$(< $BASE_DIR/.mill-version)" -- -i "${@:2}"
  ;;
 
  test)


### PR DESCRIPTION
Also make the `ci` script resolve it's directory when it needs
find `.tool-versions` and `.mill-version` files. This allows us
to run `ci` from nested directories